### PR TITLE
fix: 修复self.rolling为false时日志路径问题

### DIFF
--- a/lib/logger.lua
+++ b/lib/logger.lua
@@ -57,12 +57,7 @@ local function flushUnlock(self)
 end
 
 local function writeFile(self, value)
-    local fileName = ''
-    if self.rolling then
-        fileName = self.prefix .. ngx.today() .. ".log"
-    else
-        fileName = self.logPath
-    end
+    local fileName = self.rolling and (self.prefix .. ngx.today() .. ".log") or self.logPath .. "hack.log"
 
 	local file = io.open(fileName, "a+")
 
@@ -74,7 +69,6 @@ local function writeFile(self, value)
 	file:flush()
 	file:close()
 
-	return
 end
 
 local function flushBuffer(self)


### PR DESCRIPTION
默认日志以虚拟主机名+当前日期命名，self.rolling如果设置false，日志路径无法生成文件。

判断self.rolling为false时指定hack.log作为日志文件。

@bukaleyang logger.lua这个文件内代码之前没有格式化，如果可以合并你再格式化下吧